### PR TITLE
BugFix: LatexErrors() command now changes directory to the tex root

### DIFF
--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -201,7 +201,13 @@ function! LatexBox_LatexErrors(jump, ...)
 		let log = LatexBox_GetLogFile()
 	endif
 
-	execute 'cd ' . LatexBox_GetTexRoot()
+	if getcwd() !=# LatexBox_GetTexRoot()
+		redraw
+		echohl WarningMsg
+		echomsg 'Changing directory to TeX root: ' . LatexBox_GetTexRoot() . ' to support error log parsing'
+		echohl None
+		execute 'cd ' . LatexBox_GetTexRoot()
+	endif
 
 	if (a:jump)
 		execute 'cfile ' . fnameescape(log)


### PR DESCRIPTION
so that :cfile and such commands actually work.

This is a slight hack, but I don't know another way around it yet (other than just a warning about the wrong pwd, and then ignoring the command)
