### PR TITLE
complete previously-writen-to-file inline maths elsewhere

### DIFF
--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -1,150 +1,65 @@
 " LaTeX Box common functions
 
-" Settings {{{
+" Error Format {{{
+" This assumes we're using the -file-line-error with [pdf]latex.
+if !exists("g:LatexBox_ignore_warnings")
+	let g:LatexBox_show_warnings = 1
+	let g:LatexBox_ignore_warnings =['Underfull', 'Overfull', 'specifier changed to']
+endif
 
-" Compilation {{{
 
-" g:vim_program {{{
-if !exists('g:vim_program')
 
-	if match(&shell, '/\(bash\|zsh\)$') >= 0
-		let ppid = '$PPID'
-	else
-		let ppid = '$$'
-	endif
-
-	" attempt autodetection of vim executable
-	let g:vim_program = ''
-	let tmpfile = tempname()
-	silent execute '!ps -o command= -p ' . ppid . ' > ' . tmpfile
-	for line in readfile(tmpfile)
-		let line = matchstr(line, '^\S\+\>')
-		if !empty(line) && executable(line)
-			let g:vim_program = line . ' -g'
-			break
-		endif
-	endfor
-	call delete(tmpfile)
-
-	if empty(g:vim_program)
-		if has('gui_macvim')
-			let g:vim_program = '/Applications/MacVim.app/Contents/MacOS/Vim -g'
+" ignore certain common warnings
+if g:LatexBox_show_warnings
+	for i in range(len(g:LatexBox_ignore_warnings))
+		let warning = escape(substitute(g:LatexBox_ignore_warnings[i], '[\,]', '%\\\\&', 'g'), ' ')
+		if i==0
+			let opr = '='
 		else
-			let g:vim_program = v:progname
+			let opr = '+='
 		endif
-	endif
+		exe 'setlocal efm' . opr . '%-G%.%#'. warning .'%.%#'
+	endfor
+end
+" see |errorformat-LaTeX|
+setlocal efm+=%E!\ LaTeX\ %trror:\ %m
+setlocal efm+=%E!\ %m
+setlocal efm+=%E%f:%l:\ %m
+if g:LatexBox_show_warnings
+	setlocal efm+=%+WLaTeX\ %.%#Warning:\ %.%#line\ %l%.%#
+	setlocal efm+=%+W%.%#\ at\ lines\ %l--%*\\d
+	setlocal efm+=%+WLaTeX\ %.%#Warning:\ %m
 endif
-" }}}
-
-if !exists('g:LatexBox_latexmk_options')
-	let g:LatexBox_latexmk_options = ''
-endif
-if !exists('g:LatexBox_output_type')
-	let g:LatexBox_output_type = 'pdf'
-endif
-if !exists('g:LatexBox_viewer')
-	let g:LatexBox_viewer = 'xdg-open'
-endif
-if !exists('g:LatexBox_autojump')
-	let g:LatexBox_autojump = 0
-endif
-" }}}
-
-" Completion {{{
-if !exists('g:LatexBox_completion_close_braces')
-	let g:LatexBox_completion_close_braces = 1
-endif
-if !exists('g:LatexBox_bibtex_wild_spaces')
-	let g:LatexBox_bibtex_wild_spaces = 1
-endif
-
-if !exists('g:LatexBox_cite_pattern')
-	let g:LatexBox_cite_pattern = '\C\\cite\(p\|t\)\=\*\=\(\[[^\]]*\]\)*\_\s*{'
-endif
-if !exists('g:LatexBox_ref_pattern')
-	let g:LatexBox_ref_pattern = '\C\\v\?\(eq\|page\)\?ref\*\?\_\s*{'
-endif
-
-" define input filename extentions
-" what if no file type extention ? Not allowed!!!
-if !exists('g:LatexBox_input_filename_pattern')
-	let g:LatexBox_input_filename_pattern = '
-				\[^}]*\.tex'
-endif
-
-if !exists('g:LatexBox_doc_structure_pattern')
-	let g:LatexBox_doc_structure_pattern = '
-				\\\begin\s*{document}\|
-				\\\chapter\*\?\s*{\|
-				\\\section\*\?\s*{\|
-				\\\subsection\*\?\s*{\|
-				\\\subsubsection\*\?\s*{'
-endif
-
-if !exists('g:LatexBox__eq_env_patterns')
-	let g:LatexBox_eq_env_patterns = 'equation\|gather\|multiline\|align\|flalign\|alignat\|eqnarray'
-endif
-
-if !exists('g:LatexBox_completion_environments')
-	let g:LatexBox_completion_environments = [
-		\ {'word': 'itemize',		'menu': 'bullet list' },
-		\ {'word': 'enumerate',		'menu': 'numbered list' },
-		\ {'word': 'description',	'menu': 'description' },
-		\ {'word': 'center',		'menu': 'centered text' },
-		\ {'word': 'figure',		'menu': 'floating figure' },
-		\ {'word': 'table',			'menu': 'floating table' },
-		\ {'word': 'equation',		'menu': 'equation (numbered)' },
-		\ {'word': 'align',			'menu': 'aligned equations (numbered)' },
-		\ {'word': 'align*',		'menu': 'aligned equations' },
-		\ {'word': 'document' },
-		\ {'word': 'abstract' },
-		\ ]
-endif
-
-if !exists('g:LatexBox_completion_commands')
-	let g:LatexBox_completion_commands = [
-		\ {'word': '\begin{' },
-		\ {'word': '\end{' },
-		\ {'word': '\item' },
-		\ {'word': '\label{' },
-		\ {'word': '\caption{' },
-		\ {'word': '\ref{' },
-		\ {'word': '\eqref{eq:' },
-		\ {'word': '\cite{' },
-		\ {'word': '\chapter{' },
-		\ {'word': '\section{' },
-		\ {'word': '\subsection{' },
-		\ {'word': '\subsubsection{' },
-		\ {'word': '\paragraph{' },
-		\ {'word': '\nonumber' },
-		\ {'word': '\bibliography' },
-		\ {'word': '\bibliographystyle' },
-		\ ]
-endif
+"ignore unmatched lines
+setlocal efm+=%-G\\s%#
+setlocal efm+=%-G%.%#
 " }}}
 
 " Vim Windows {{{
+
+" width of vertical splits
 if !exists('g:LatexBox_split_width')
 	let g:LatexBox_split_width = 30
 endif
-" }}}
+
+" where vertical splits appear
+if !exists('g:LatexBox_split_side')
+	let g:LatexBox_split_side = "leftabove"
+endif
+
 " }}}
 
 " Filename utilities {{{
-"
+
 function! LatexBox_GetMainTexFile()
 
 	" 1. check for the b:main_tex_file variable
-	if exists('b:main_tex_file') && glob(b:main_tex_file, 1) != ''
+	if exists('b:main_tex_file') && filereadable(b:main_tex_file)
 		return b:main_tex_file
 	endif
 
-	" 2. scan current file for "\begin{document}"
-	if &filetype == 'tex' && search('\C\\begin\_\s*{document}', 'nw') != 0
-		return expand('%:p')
-	endif
 
-	" 3. scan the first few lines of the file for root = filename
+	" 2. scan the first few lines of the file for root = filename
 	for linenum in range(1,5)
 		let linecontents = getline(linenum)
 		if linecontents =~ 'root\s*='
@@ -152,11 +67,25 @@ function! LatexBox_GetMainTexFile()
 			let b:main_tex_file = substitute(linecontents, '.*root\s*=\s*', "", "")
 			let b:main_tex_file = substitute(b:main_tex_file, '\s*$', "", "")
 			let b:main_tex_file = fnamemodify(b:main_tex_file, ":p")
+			if b:main_tex_file !~ '\.tex$'
+				let b:main_tex_file .= '.tex'
+			endif
 			return b:main_tex_file
 		endif
 	endfor
 
-	" 4. prompt for file with completion
+	" 3. scan current file for "\begin{document}"
+	if &filetype == 'tex' && search('\C\\begin\_\s*{document}', 'nw') != 0
+		return expand('%:p')
+	endif
+
+	" 4 borrow the Vim-Latex-Suite method of finding it
+	if Tex_GetMainFileName() != expand('%:p')
+		let b:main_tex_file = Tex_GetMainFileName()
+		return b:main_tex_file
+	endif
+
+	" 5. prompt for file with completion
 	let b:main_tex_file = s:PromptForMainFile()
 	return b:main_tex_file
 endfunction
@@ -165,12 +94,13 @@ function! s:PromptForMainFile()
 	let saved_dir = getcwd()
 	execute 'cd ' . fnameescape(expand('%:p:h'))
 	let l:file = ''
-	while glob(l:file, 1) == ''
+	while !filereadable(l:file)
 		let l:file = input('main LaTeX file: ', '', 'file')
 		if l:file !~ '\.tex$'
 			let l:file .= '.tex'
 		endif
 	endwhile
+	let l:file = fnamemodify(l:file, ':p')
 	execute 'cd ' . fnameescape(saved_dir)
 	return l:file
 endfunction
@@ -222,9 +152,9 @@ command! LatexView			call LatexBox_View()
 " LatexBox_InComment([line], [col])
 " return true if inside comment
 function! LatexBox_InComment(...)
-	let line	= a:0 >= 1 ? a:1 : line('.')
-	let col		= a:0 >= 2 ? a:2 : col('.')
-	return synIDattr(synID(line("."), col("."), 0), "name") =~# '^texComment'
+	let line = a:0 >= 1 ? a:1 : line('.')
+	let col = a:0 >= 2 ? a:2 : col('.')
+	return synIDattr(synID(line, col, 0), "name") =~# '^texComment'
 endfunction
 " }}}
 
@@ -297,7 +227,6 @@ function! LatexBox_GetCurrentEnvironment(...)
 endfunction
 " }}}
 
-
 " Tex To Tree {{{
 " stores nested braces in a tree structure
 function! LatexBox_TexToTree(str)
@@ -311,7 +240,7 @@ function! LatexBox_TexToTree(str)
 			let i2 = len(a:str)
 		endif
 		if i2 >= len(a:str) || a:str[i2] == '{'
-			if depth == 0 
+			if depth == 0
 				let item = substitute(strpart(a:str, i1, i2 - i1), '^\s*\|\s*$', '', 'g')
 				if !empty(item)
 					call add(tree, item)

--- a/readme.hli
+++ b/readme.hli
@@ -1,6 +1,0 @@
-the difference: added eq completion
-
-To merge 
-git fetch LaTeX-Box-Team
-git merge LaTeX-Box-Team/master
-


### PR DESCRIPTION
I: anywhere with `$ [space] [part-of-eq] Ctrl-x Ctrl-o`
II: after `\(, \[ or \begin{eq-env}` with `[space] [part-of-eq] Ctrl-x Ctrl-o` in the same line or other lines followed

ATTENTION: 
only try to match form the writen-to-file eqs. 
can only complete eq-env by first typing `\end{`
