### PR TITLE
Add support for specifying the main LaTeX file in a comment

### DIFF
--- a/doc/latex-box.txt
+++ b/doc/latex-box.txt
@@ -422,6 +422,12 @@ A: Instead of putting the settings in your ~/.latexmkrc file, put them in your
 	$pdflatex = 'xelatex %O %S'
 <
 
+Q: How can I specify the main TeX file for a multi-file document
+
+A: Add a comment to the first few lines of your file to specify this: >
+	%! TEX root = main.tex'
+<
+
 ==============================================================================
 
 TODO						*latex-box-todo*

--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -123,7 +123,19 @@ function! LatexBox_GetMainTexFile()
 		return expand('%:p')
 	endif
 
-	" 3. prompt for file with completion
+	" 3. scan the first few lines of the file for root = filename
+	for linenum in range(1,5)
+		let linecontents = getline(linenum)
+		if linecontents =~ 'root\s*='
+			" Remove everything but the filename
+			let b:main_tex_file = substitute(linecontents, '.*root\s*=\s*', "", "")
+			let b:main_tex_file = substitute(b:main_tex_file, '\s*$', "", "")
+			let b:main_tex_file = fnamemodify(b:main_tex_file, ":p")
+			return b:main_tex_file
+		endif
+	endfor
+
+	" 4. prompt for file with completion
 	let b:main_tex_file = s:PromptForMainFile()
 	return b:main_tex_file
 endfunction


### PR DESCRIPTION
Any line in the first five lines of the file that contains 'root' followed by
any number of spaces, followed by a equals sign, followed by a filename will
work. The typical format is:

%!TEX root = main.tex

To set the main file to main.tex.

This is the same comment used to specify the filename in Texworks.
