### PR TITLE
Do not indent after a newline command anylonger

### DIFF
--- a/ftplugin/latex-box/indent.vim
+++ b/ftplugin/latex-box/indent.vim
@@ -13,9 +13,9 @@ setlocal indentkeys==\end,=\item,),],},o,0\\
 let s:itemize_envs = ['itemize', 'enumerate', 'description']
 
 " indent on \left( and on \(, but not on (
-" indent on \left[ and on \[, but not on [
+" indent on \left[ and on \[, but not on [ and \[...]
 " indent on \left\{ and on \{, and on {
-let s:open_pat = '\\begin\>\|\%(\\left\s*\)\=\\\=[{]\|\%(\\left\s*\|\\\)[[(]'
+let s:open_pat = '\\begin\>\|\%(\\left\s*\)\=\\\=[{]\|\%(\\left\s*\|\\\)\([[]\(\p\+]\)\@!\|[)]\)'
 let s:close_pat = '\\end\>\|\%(\\right\s*\)\=\\\=[}]\|\%(\\right\s*\|\\\)[])]'
 
 


### PR DESCRIPTION
I'm frequently using the 

\[extra-space] 

command in my .tex files for the layout of the title page etc. After a 'gg=G' in those files, it yields an awful indented file. With my commit i fixed that issue. Maybe the regular expression isn't the prettiest, but it does for what it's intended to.

with best regards...
