### PR TITLE
User can determine where vsplits (TOC) appears.

### DIFF
--- a/doc/latex-box.txt
+++ b/doc/latex-box.txt
@@ -189,6 +189,7 @@ Motion ~
 	Open a table of contents.
 	Use Enter to navigate to selected entry.
 	See |g:LatexBox_split_width|.
+	See |g:LatexBox_split_side|.
 
 
 
@@ -402,6 +403,12 @@ Vim Windows ~
 
 	Width of vertically split vim windows. Used for the table of contents.
 
+
+*g:LatexBox_split_side*	Default: "leftabove"
+
+	On which side the vertically split windows appear.  Used for the
+	table of contents.
+	Set it to "rightbelow" to have it on the right side.
 
 ==============================================================================
 

--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -103,9 +103,17 @@ endif
 " }}}
 
 " Vim Windows {{{
+
+" width of vertical splits
 if !exists('g:LatexBox_split_width')
 	let g:LatexBox_split_width = 30
 endif
+
+" where vertical splits appear
+if !exists('g:LatexBox_split_side')
+	let g:LatexBox_split_side = "leftabove"
+endif
+
 " }}}
 " }}}
 

--- a/ftplugin/latex-box/motion.vim
+++ b/ftplugin/latex-box/motion.vim
@@ -349,7 +349,7 @@ function! LatexBox_TOC()
 	" find closest section in current buffer
 	let closest_index = s:FindClosestSection(toc)
 
-	execute g:LatexBox_split_width . 'vnew LaTeX\ TOC'
+	execute g:LatexBox_split_side g:LatexBox_split_width . 'vnew LaTeX\ TOC'
 	setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nowrap cursorline nonumber
 
 	for entry in toc


### PR DESCRIPTION
From doc/lasex-box.txt:

```
*g:LatexBox_split_side* Default: "leftabove"

    On which side the vertically split windows appear.  Used for the
    table of contents.
    Set it to "rightbelow" to have it on the right side.
```
