### PR TITLE
Improved completion

### DIFF
--- a/ftplugin/latex-box/complete.vim
+++ b/ftplugin/latex-box/complete.vim
@@ -159,7 +159,6 @@ function! LatexBox_BibSearch(regexp)
 
 	" find bib data
     let bibdata = s:FindBibData()
-	let g:test = bibdata
     if bibdata == ''
         echomsg 'error: no \bibliography{...} command found'
         return


### PR DESCRIPTION
Hi,

This request addresses an issue with the completion function in complete.vim where `break` was used instead of `continue`, which made the label completion not work (at least it did not work for me). I also did a minor update to syntax (changed some extra empty lines and changed from space to tabs at some locations (since main author insists on noexpandtab in the modline).

Bonus: It also fixes a stupid mistake I made to folding.vim where I used `s:...` instead of `g:...`.
