### PR TITLE
Adding doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
I use pathogen and git submodules to manage most of my vim plugins. I also generate documentation tags for each plugin. However, if an untracked (and not ignored) file exists in a submodule's directory, it requires more steps to update the submodule and then regenerate the file.
