### PR TITLE
Prepend current directory to path of main TeX file specified by '! TEX root =' comment

### DIFF
--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -66,6 +66,10 @@ function! LatexBox_GetMainTexFile()
 			" Remove everything but the filename
 			let b:main_tex_file = substitute(linecontents, '.*root\s*=\s*', "", "")
 			let b:main_tex_file = substitute(b:main_tex_file, '\s*$', "", "")
+			" Prepend current directory if this isn't an absolute path
+			if b:main_tex_file !~ '^/'
+				let b:main_tex_file = expand('%:p:h') . '/' . b:main_tex_file
+			endif
 			let b:main_tex_file = fnamemodify(b:main_tex_file, ":p")
 			if b:main_tex_file !~ '\.tex$'
 				let b:main_tex_file .= '.tex'


### PR DESCRIPTION
Compilation of a multi-file document doesn't work if the main TeX file hasn't been opened by the same instance of vim. This patch treats the file name in the '! TEX root =' comment as a file relative to the file containing the comment, unless it starts with a '/'.
