### PR TITLE
Add :LatexTOCToggle command to toggle TOC display

### DIFF
--- a/doc/latex-box.txt
+++ b/doc/latex-box.txt
@@ -280,6 +280,8 @@ Motion ~
 	Use Enter to navigate to selected entry.
 	See |g:LatexBox_split_width|.
 	See |g:LatexBox_split_side|.
+*:LatexTOCToggle*
+	Toggle the display of the table of contents.
 
 Associated setting:
 	|g:LatexBox_plaintext_toc| (set this if UTF8 conversion does not work)

--- a/ftplugin/latex-box/motion.vim
+++ b/ftplugin/latex-box/motion.vim
@@ -416,12 +416,18 @@ function! s:ReadTOC(auxfile, ...)
 
 endfunction
 
-function! LatexBox_TOC()
+function! LatexBox_TOC(...)
 
 	" Check if window already exists
 	let winnr = bufwinnr(bufnr('LaTeX TOC'))
 	if winnr >= 0
-		silent execute winnr . 'wincmd w'
+		if a:0 == 0
+			silent execute winnr . 'wincmd w'
+		else
+			" Supplying an argument to this function causes toggling instead
+			" of jumping to the TOC window
+			silent execute 'bwipeout' . bufnr('LaTeX TOC')
+		endif
 		return
 	endif
 
@@ -599,6 +605,7 @@ endfunction
 
 " TOC Command {{{
 command! LatexTOC call LatexBox_TOC()
+command! LatexTOCToggle call LatexBox_TOC(1)
 " }}}
 
 " vim:fdm=marker:ff=unix:noet:ts=4:sw=4


### PR DESCRIPTION
I find it useful to have a toggle command in addition to the normal :LatexTOC command which opens/jumps to the TOC.
