### PR TITLE
Add option to make the quickfix window not active when shown

### DIFF
--- a/doc/latex-box.txt
+++ b/doc/latex-box.txt
@@ -502,7 +502,15 @@ Compilation ~
 
 *g:LatexBox_quickfix*		Default: 1
 
-	If set to 0, disable automatic quickfix window.
+	Adjust the behavior of the quickfix window when there are compilation errors or
+	warnings (according to the value of |g:LatexBox_show_warnings|):
+
+	Value		Effect ~
+	0		The quickfix is not opened automatically.
+	1		The quickfix window is opened automatically if not
+			empty and becomes the active window.
+	2		The quickfix window is opened automatically if not
+			empty but the cursor stays in the current window.
 
 *g:LatexBox_autojump*		Default: 0
 
@@ -517,7 +525,7 @@ Compilation ~
 
 *g:LatexBox_show_warnings*	Default: 1
 
-	If set to 1, warnings in complication will be listed as errors.
+	If set to 1, warnings in compilation will be listed as errors.
 
 *g:LatexBox_ignore_warnings*	Default: ['Underfull', 'Overfull', 'specifier changed to']
  

--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -265,6 +265,9 @@ function! LatexBox_LatexErrors(status, ...)
 	if g:LatexBox_quickfix
 		ccl
 		cw
+		if g:LatexBox_quickfix==2
+			wincmd p
+		endif
 	endif
 
 	if a:status


### PR DESCRIPTION
One can now do
`let g:LatexBox_quickfix_active=0` to make the quickfix window not
active when shown: the cursor stays in the current window.
If `g:LatexBox_quickfix` is set to `0`, this setting has no effect.

This is useful for me because I call Latexmk automatically when the buffer is written, and this allows me to see errors while not interrupting the flow of editing.
