### PR TITLE
Noserver

### DIFF
--- a/doc/latex-box.txt
+++ b/doc/latex-box.txt
@@ -238,23 +238,23 @@ Compilation ~
         Compile with latexmk.
         See |g:LatexBox_latexmk_async|, |g:LatexBox_latexmk_options|, and
         |g:LatexBox_latexmk_preview_continuously|.
-*:LatexmkForce*
-        Force compilation with latexmk in background.
+*:Latexmk!*
+        Force compilation with latexmk (runs latexmk with "-g" option).
 *:LatexmkClean*
         Clean temporary output from LaTeX.
-*:LatexmkCleanAll*
+*:LatexmkClean!*
         Clean all output from LaTeX.
-*:LatexmkStop*
-        Stop latexmk if it is running.
 *:LatexmkStatus*
         Show the running status of latexmk for the current buffer.
-*:LatexmkStatusDetailed*
+*:LatexmkStatus!*
         Show the running status of latexmk for all buffers with process group
-        ID's (only available when |g:LatexBox_latexmk_async| is set to 1).
+        ID's or PID's.
+*:LatexmkStop*
+        Stop latexmk if it is running.
 *:LatexErrors*
         Load the log file for the current document and jump to the first error.
 
-Note: The commands |:LatexmkStop| and |:LatexmkStatus| are only available when
+Note: The commands |:LatexmkStop| and |:LatexmkStatus| are only relevant when
 |g:LatexBox_latexmk_async| or |g:LatexBox_latexmk_preview_continuously| is
 set.
 
@@ -305,17 +305,17 @@ Compilation ~
 
 <LocalLeader>ll                                                     |:Latexmk|
         Compile with latexmk.
-<LocalLeader>lL                                                |:LatexmkForce|
-        Force compilation with latexmk in background.
+<LocalLeader>lL                                                    |:Latexmk!|
+        Force compilation with latexmk.
 <LocalLeader>lc                                                |:LatexmkClean|
         Clean temporary output from LaTeX.
-<LocalLeader>lC                                             |:LatexmkCleanAll|
+<LocalLeader>lC                                               |:LatexmkClean!|
         Clean all output from LaTeX.
 <LocalLeader>lk                                                 |:LatexmkStop|
         Stop latexmk if it is running.
 <LocalLeader>lg                                               |:LatexmkStatus|
         Show the running status of latexmk for the current buffer.
-<LocalLeader>lG                                       |:LatexmkStatusDetailed|
+<LocalLeader>lG                                              |:LatexmkStatus!|
         Show the running status of latexmk for all buffers with process group
         ID's.
 <LocalLeader>le                                                 |:LatexErrors|
@@ -508,8 +508,7 @@ Compilation ~
         Run latexmk in continuous mode (i.e. with the "-pvc" option).
         Latexmk will track the currently edited file for writes and
         recompile automatically when necessary, without hanging VIM. Note that
-        unless the |g:LatexBox_latexmk_async| option is also set, this will
-        disable automatic error loading.
+        this will disable automatic error loading.
 
 *g:LatexBox_latexmk_options*                    Default: ""
         Additional options to pass to latexmk during compilation, e.g, "-d".

--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -363,14 +363,13 @@ endfunction
 
 command! -bang	Latexmk			call LatexBox_Latexmk(<q-bang> == "!")
 command! -bang	LatexmkClean	call LatexBox_LatexmkClean(<q-bang> == "!")
+command! -bang	LatexmkStatus	call LatexBox_LatexmkStatus(<q-bang> == "!")
+command! LatexmkStop			call LatexBox_LatexmkStop(0)
 command! LatexErrors			call LatexBox_LatexErrors(-1)
 
 if g:LatexBox_latexmk_async || g:LatexBox_latexmk_preview_continuously
 	autocmd BufUnload <buffer> 	call LatexBox_LatexmkStop(1)
 	autocmd VimLeave * 			call <SID>kill_all_latexmk_processes()
-
-	command! -bang	LatexmkStatus		call LatexBox_LatexmkStatus(<q-bang> == "!")
-	command! LatexmkStop				call LatexBox_LatexmkStop(0)
 endif
 
 " }}}


### PR DESCRIPTION
This branch combines the background (asynchronous) tex compilation of the `master` branch with the simpler approach of the `portable_lmk` and `remove_vimserver` branches. The main contributions are:
- There are now two additional commands `LatexmkAsync` and `LatexmkSync` to compile latex. Most importantly, `LatexmkSync` doesn't require a vim server to run. Both commands have the mappings you would expect: `<leader>la`, etc.
- There are two new global options:
  -  `g:Latexmk_async` which controls what the default command `Latexmk` does. For consistence with the current master branch it is set to 1 by default (so by default running `Latexmk` will run `LatexmkAsync`). Setting this option to 0 makes `LatexmkSync` the default (and also skips all the asynchronous setup in the plugin configuration).
  - `g:Latexmk_autosave` which saves the file automatically before compiling when set (default is unset).

Also a bug fix:
- Running `LatexErrors` used to change vim's current working directory, which could be a problem. This is now fixed and you can view any compilation errors from the quickfix window and keep your current working directory.

Disclaimer:
I am submitting this pull request without having tested background compiling (I am unable to run a vim server on my machine, which is the reason behind this pull request). I didn't change any of the relevant asynchronous code and only moved it inside conditional statements. If someone could check that it works, I would be very grateful since I believe there would be a lot of benefit to having both compilation modes available in this great plugin.
