### PR TITLE
Disabled syntax highlighting for \c{page,}refrange

### DIFF
--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -2,9 +2,3 @@
 " \Cref, \cref, \cpageref, \labelcref, \labelcpageref
 syn region texRefZone		matchgroup=texStatement start="\\Cref{"				end="}\|%stopzone\>"	contains=@texRefGroup
 syn region texRefZone		matchgroup=texStatement start="\\\(label\|\)c\(page\|\)ref{"	end="}\|%stopzone\>"	contains=@texRefGroup
-" \crefrange, \cpagerefrange (these commands expect two arguments)
-syn match texStatement		'\\c\(page\|\)refrange\>'					nextgroup=texRefRangeStart
-syn region texRefRangeStart	matchgroup=texStatement start='{' end='}' contains=texRefZone	nextgroup=texRefRangeEnd
-syn region texRefRangeEnd	matchgroup=texStatement start='{' end='}' contains=texRefZone
-hi link	texRefRangeStart	texRefZone
-hi link	texRefRangeEnd		texRefZone


### PR DESCRIPTION
My syntax file was buggy, sorry! The syntax highlighting of a relatively large tex file I'm currently working on got completely screwed up when I used the new syntax/tex.vim. The problem is the \crefrange command. No idea how to highlight that correctly.
