### PR TITLE
Add synctex support

### DIFF
--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -14,6 +14,9 @@ endif
 if !exists('g:LatexBox_latexmk_preview_continuously')
 	let g:LatexBox_latexmk_preview_continuously = 0
 endif
+if !exists('g:LatexBox_enable_synctex')
+	let g:LatexBox_enable_synctex = 1
+endif
 if !exists('g:LatexBox_output_type')
 	let g:LatexBox_output_type = 'pdf'
 endif
@@ -178,6 +181,10 @@ function! LatexBox_Latexmk(force)
 	endif
 	if g:LatexBox_latexmk_preview_continuously
 		let cmd .= ' -pvc'
+	endif
+	if g:LatexBox_enable_synctex
+		let cmd .= ' -e ' . shellescape('$pdflatex =~ s/ / -synctex=1 /')
+		let cmd .= ' -e ' . shellescape('$latex =~ s/ / -synctex=1 /')
 	endif
 	let cmd .= ' -e ' . shellescape('$pdflatex =~ s/ / -file-line-error /')
 	let cmd .= ' -e ' . shellescape('$latex =~ s/ / -file-line-error /')

--- a/ftplugin/latex-box/mappings.vim
+++ b/ftplugin/latex-box/mappings.vim
@@ -19,6 +19,11 @@ map <buffer> <LocalLeader>le :LatexErrors<CR>
 map <buffer> <LocalLeader>lv :LatexView<CR>
 " }}}
 
+" Synctex {{{
+if g:LatexBox_enable_synctex
+	map <buffer> <LocalLeader>ls :LatexForwardSearch<CR>
+endif
+
 " TOC {{{
 map <silent> <buffer> <LocalLeader>lt :LatexTOC<CR>
 " }}}

--- a/ftplugin/latex-box/synctex-zathura.sh
+++ b/ftplugin/latex-box/synctex-zathura.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#Helper script for synctex backward search with zathura
+# $1 : v:progname
+# $2 : v:servername
+# $3 : %{page+1}
+# $4 : %{output}
+zathura -s -x "$1 --servername $2 --remote-expr 'LatexBox_Synctex_Backward(\"%{input}\",%{line})'" -P $3 $4

--- a/ftplugin/latex-box/synctex.vim
+++ b/ftplugin/latex-box/synctex.vim
@@ -1,0 +1,36 @@
+" Latex Box synctex support
+if ! g:LatexBox_enable_synctex
+	finish
+endif
+
+if ! exists("g:LatexBox_synctex_viewer")
+	if has("macunix")
+		let g:LatexBox_synctex_viewer = "skim"
+	elseif has("unix")
+		if executable("zathura")
+			let g:LatexBox_synctex_viewer = "zathura"
+		else
+			let g:LatexBox_synctex_viewer = "evince"
+		endif
+	endif
+endif
+
+let s:plugin_path = expand('<sfile>:p:h')
+
+function LatexBox_Synctex_Forward()
+	if g:LatexBox_synctex_viewer == "zathura" || g:LatexBox_synctex_viewer == "evince"
+		"For both viewers, we use the 'synctex' executable to provide
+		"the right page
+		let cmd="synctex view -i " . line('.') . ":0:" . expand("%:p") . " -o " . LatexBox_GetOutputFile()
+		if g:LatexBox_synctex_viewer == "zathura"
+			let cmd .= " -x " . shellescape(s:plugin_path . "/synctex-zathura.sh " . v:progname . " " . v:servername . " %{page+1} %{output}",1) 
+		elseif g:LatexBox_synctex_viewer == "evince"
+			let cmd .= " -x " . shellescape('evince -i %{page+1} %{output}',1) 
+		endif
+		silent execute "!" . cmd . " &"
+	else
+		echoerr "LatexBox has no Synctex implementation for your platform"
+	endif
+endfunction
+
+command! LatexForwardSearch call LatexBox_Synctex_Forward()

--- a/ftplugin/tex_LatexBox.vim
+++ b/ftplugin/tex_LatexBox.vim
@@ -21,6 +21,7 @@ if !exists('b:LatexBox_loaded')
 	execute 'source ' . s:FNameEscape(prefix . 'complete.vim')
 	execute 'source ' . s:FNameEscape(prefix . 'motion.vim')
 	execute 'source ' . s:FNameEscape(prefix . 'latexmk.vim')
+	execute 'source ' . s:FNameEscape(prefix . 'synctex.vim')
 	execute 'source ' . s:FNameEscape(prefix . 'folding.vim')
 	" added by AH to add main.tex file finder
 	execute 'source ' . s:FNameEscape(prefix . 'findmain.vim')

--- a/plugin/synctex.vim
+++ b/plugin/synctex.vim
@@ -1,0 +1,21 @@
+if ! g:LatexBox_enable_synctex
+	finish
+endif
+
+" This function is needed because synctex adds an addition "./" in the path
+" and standard "vim --remote +line file" syntax cannot be used as a
+" consequence
+function! LatexBox_Synctex_Backward(path,line)
+	let l:swb=&switchbuf
+	let &switchbuf="useopen,usetab"
+	let l:file=substitute(a:path,"\\./","","")
+	if buflisted(l:file)
+		let l:open = "sbuffer"
+	else
+		let l:open = "split"
+	endif
+	silent execute l:open . " " . l:file
+	execute "normal! " . a:line . "Gzv"
+	let &switchbuf=l:swb
+endfunction
+


### PR DESCRIPTION
Hello,

I added Synctex support to LatexBox.
Currently, it only works for evince (only forward search, proper support requires DBus which is too involved for me) and zathura (also backward search).
I also plan to add support for skim on OS X, which I use at work, but this will have to wait until I can test it on the mac. I have not written proper documentation yet either.

Please let me know what you think of this patch.
I am not very happy about the backward search implementation, which needs a whole global function to work around the fact that synctex writes the file paths like so `/path/to/file/./document.tex` which `vim` does not like. Maybe it is better to write a small bash script to take care of this and use the standard `vim --remote +line document.tex` instead?
There is already a small wrapper script to call zathura, I tried without at first but ended in a nightmare of shell escaping. If anyone manages to make it work directly in vim script, it would probably be better.
