### PR TITLE
latexmk '-lualatex' option support

### DIFF
--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -186,8 +186,12 @@ function! LatexBox_Latexmk(force)
 	if g:LatexBox_latexmk_preview_continuously
 		let cmd .= ' -pvc'
 	endif
-	let cmd .= ' -e ' . shellescape('$pdflatex =~ s/ / -file-line-error /')
-	let cmd .= ' -e ' . shellescape('$latex =~ s/ / -file-line-error /')
+	" lualatex mode cannot treat these kind of initialization codes
+	" so just ignore it if g:LatexBox_latexmk_options include '-lualatex'
+	if !(g:LatexBox_latexmk_options =~ '-lualatex')
+		let cmd .= ' -e ' . shellescape('$pdflatex =~ s/ / -file-line-error /')
+		let cmd .= ' -e ' . shellescape('$latex =~ s/ / -file-line-error /')
+	endif
 	if g:LatexBox_latexmk_preview_continuously
 		let cmd .= ' -e ' . shellescape('$success_cmd = $ENV{SUCCESSCMD}')
 		let cmd .= ' -e ' . shellescape('$failure_cmd = $ENV{FAILURECMD}')


### PR DESCRIPTION
It seem like `latexmk` does not work correctly when '-lualatex' and
'-e "$latex=...."' options were passed together.

This commit will fix this issue by ignoreing -e options when '-lualatex'
is specified in `g:LatexBox_latexmk_options`

I'm not really familiar with `latexmk` but the old style (?) lualatex
specification ('-pdflatex="lualatex %O %S"') is not supported with
this commit.
