### PR TITLE
Modified PID for Linux/non-async 

### DIFF
--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -325,7 +325,7 @@ function! LatexBox_Latexmk(force)
 				let g:latexmk_running_pids[basepath] = pid
 			else
 				let pid = substitute(system('pgrep -f "perl.*'
-							\ . mainfile . '"'),'\D','','')
+							\ . mainfile . '" | head -n 1'),'\D','','')
 				let g:latexmk_running_pids[basepath] = pid
 			endif
 		else


### PR DESCRIPTION
Modified PID for Linux/non-async to only read in first result (actual perl job rather than system call)

This fixes the non-asynchronous part of issue https://github.com/LaTeX-Box-Team/LaTeX-Box/issues/153
