### PR TITLE
Fixed #124 - support for the listings package.

### DIFF
--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -2,3 +2,8 @@
 " \Cref, \cref, \cpageref, \labelcref, \labelcpageref
 syn region texRefZone		matchgroup=texStatement start="\\Cref{"				end="}\|%stopzone\>"	contains=@texRefGroup
 syn region texRefZone		matchgroup=texStatement start="\\\(label\|\)c\(page\|\)ref{"	end="}\|%stopzone\>"	contains=@texRefGroup
+
+" adds support for listings package
+syn region texZone start="\\begin{lstlisting}" end="\\end{lstlisting}\|%stopzone\>"
+syn region texZone  start="\\lstinputlisting" end="{\s*[a-zA-Z/.0-9_^]\+\s*}"
+syn match texInputFile "\\lstinline\s*\(\[.*\]\)\={.\{-}}" contains=texStatement,texInputCurlies,texInputFileOpt


### PR DESCRIPTION
Added support for environments/commands included in the listings package that commonly contains $ _ and other characters with special meaning in LaTeX, potentially breaking syntax highlighting. 

For more information see [#124](https://github.com/LaTeX-Box-Team/LaTeX-Box/issues/124) (not sure if it'll be automatically linked by Github or not..)
