### PR TITLE
Correctly find main file when user has non-standard magicness

### DIFF
--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -102,7 +102,7 @@ function! LatexBox_GetMainTexFile()
 	endfor
 
 	" 3. scan current file for "\begin{document}"
-	if &filetype == 'tex' && search('\C\\begin\_\s*{document}', 'nw') != 0
+	if &filetype == 'tex' && search('\m\C\\begin\_\s*{document}', 'nw') != 0
 		return expand('%:p')
 	endif
 


### PR DESCRIPTION
Adds a `\m` to the `search()` call in `GetMainTexFile()`, which otherwise breaks if the user sets `nomagic` or some other non-default magicness.
This would break LaTeX-Box realising that the current file is a main file in those circumstances.
