### PR TITLE
fix syntax

### DIFF
--- a/after/syntax/tex.vim
+++ b/after/syntax/tex.vim
@@ -5,5 +5,5 @@ syn region texRefZone		matchgroup=texStatement start="\\\(label\|\)c\(page\|\)re
 
 " adds support for listings package
 syn region texZone start="\\begin{lstlisting}" end="\\end{lstlisting}\|%stopzone\>"
-syn region texZone  start="\\lstinputlisting" end="{\s*[a-zA-Z/.0-9_^]\+\s*}"
-syn match texInputFile "\\lstinline\s*\(\[.*\]\)\={.\{-}}" contains=texStatement,texInputCurlies,texInputFileOpt
+syn match texInputFile  "\\lstinputlisting\s*\(\[.*\]\)\={.\{-}}" contains=texStatement,texInputCurlies,texInputFileOpt
+syn match texZone "\\lstinline\s*\(\[.*\]\)\={.\{-}}"


### PR DESCRIPTION
This is a follow up to #124.

This changes the behaviour as follows: `\lstinline` behaves like `\verb` and `\lstinputlisting` behaves as any other file input would. I think this makes much more sense and also the `lstinputlisting` was broken if any macro was used within the argument of it, like `\lstinputlisting{\MyPath/foo.bar}`. Which would result in "verbatim" syntax until the next normal latex-macro.

Edit: Fixed typos.
