### PR TITLE
Correct cite and ref pattern to include magic flag

### DIFF
--- a/doc/latex-box.txt
+++ b/doc/latex-box.txt
@@ -464,11 +464,12 @@ Completion ~
                 let LatexBox_ref_pattern = '\c\\\a*ref\*\?\_\s*{'
 <       Both of the above examples also match commands with a trailing star.
 
-        Defualt values: >
+        Default values: >
                 let g:LatexBox_cite_pattern
-                        \ = '\c\\\a*cite\a*\*\?\(\[[^\]]*\]\)\_\s*{'
+                        \ = '\m\c\\\a*cite\a*\*\?\(\[[^\]]*\]\)\_\s*{'
                 let g:LatexBox_ref_pattern
-                        \ = '\C\\v\?\(eq\|page\|[cC]\)\?ref\*\?\_\s*{'
+                        \ = '\m\C\\v\?\(eq\|page\|[cC]\)\?ref\*\?\_\s*{'
+<       The '\m' flag indicates that these are magic regular expressions.
 <       The default settings should work for most standard LaTeX packages.
 
 *g:LatexBox_complete_inlineMath*        Default: 0


### PR DESCRIPTION
See complete.vim, line 115, where the magic flag is prepended to the pattern. This is good to know if one uses an autocompletion plugin such as NeoComplete to tell it when to invoke LatexBox completion, for example:

" Use LatexBox OmniCompletion
" defaults from documentation + assumed \magic option
let s:LatexBox_cite_pattern = '\c\\a_cite\a_*\?([[^]]_])_\s_{'
let s:LatexBox_ref_pattern  = '\C\v\?(eq|page|[cC])\?ref*\?_\s*{'

let g:neocomplete#sources#omni#input_patterns.tex = '\m' .
                          \ '('.s:LatexBox_ref_pattern.')' . '|' .
                          \ '('.s:LatexBox_cite_pattern.')'
" }
