### PR TITLE
Improve formatting of multiple authors in bib completion

### DIFF
--- a/ftplugin/latex-box/complete.vim
+++ b/ftplugin/latex-box/complete.vim
@@ -328,6 +328,9 @@ function! LatexBox_BibComplete(regexp)
 		let type = printf('%-' . s:type_length . 's', type)
 		let auth = m['author'] == '' ? ''    :       m['author'][:20] . ' '
 		let auth = substitute(auth, '\~', ' ', 'g')
+        if match(auth, ",") != -1
+            let auth = matchstr(auth, '\w\+\ze,' ) . ' et al.'
+        endif
 		let year = m['year']   == '' ? ''    : '(' . m['year']   . ')'
 		let w = { 'word': m['key'],
 				\ 'abbr': type . auth . year,


### PR DESCRIPTION
This  fixes [#149](https://github.com/LaTeX-Box-Team/LaTeX-Box/issues/149): when there are three or more authors the bib completion window will display " 'surname of the first author'  et al." Please review the pull request because i) I think I've mixed spaces and tabs when indenting and ii) I'm not quite sure about the regex I used to get the first author before the comma.  
Thanks!
