### PR TITLE
fix two issues with quickfix window

### DIFF
--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -414,7 +414,6 @@ function! LatexBox_LatexErrors(status, ...)
 		botright copen
 	else
 		" Write status message to screen
-		redraw
 		if a:status > 0 || len(getqflist())>1
 			if s:log_contains_error(fnameescape(log))
 				let l:status_msg = ' ... failed!'
@@ -435,6 +434,7 @@ function! LatexBox_LatexErrors(status, ...)
 				wincmd p
 			endif
 		endif
+		redraw
 	endif
 endfunction
 


### PR DESCRIPTION
Fixes two issues I've had with the quickfix window:
1. `g:LatexBox_quickfix = 2` and below got ignored
2. quickfix window didn't appear until the next redraw
