### PR TITLE
Fix folding preamble area.

### DIFF
--- a/ftplugin/latex-box/folding.vim
+++ b/ftplugin/latex-box/folding.vim
@@ -146,9 +146,9 @@ function! LatexBox_FoldLevel(lnum)
 
     " Fold preamble
     if g:LatexBox_fold_preamble == 1
-        if line =~# '\s*\\documentclass'
+        if line =~# s:notcomment . s:notbslash . '\s*\\documentclass'
             return ">1"
-        elseif line =~# '^\s*\\begin\s*{\s*document\s*}'
+        elseif line =~# s:notcomment . s:notbslash . '\s*\\begin\s*{\s*document\s*}'
             return "0"
         endif
     endif


### PR DESCRIPTION
If there are \documentclass and \begin{document} in comments then there
are multiple folded preamble.

The fix correct the match pattern by prefix with s:noncomment and
s:bslash.
