### PR TITLE
correct cref reference filter

### DIFF
--- a/ftplugin/latex-box/complete.vim
+++ b/ftplugin/latex-box/complete.vim
@@ -366,7 +366,7 @@ function! s:ExtractLabels()
 		let curname = strpart( getline( lblline ), lblbegin, nameend - lblbegin - 1 )
 
 		" Ignore cref entries (because they are duplicates)
-		if curname =~ "@cref\|cref@"
+		if curname =~# "@cref$"
 			continue
 		endif
 


### PR DESCRIPTION
the duplicate cref entries always appear with `@cref` at the end of the entry. gVim does not interpret the previous regex as expected (gVim 7.4.346 under Windows 7 64 bit).
