### PR TITLE
Add support for on demand folding

### DIFF
--- a/doc/latex-box.txt
+++ b/doc/latex-box.txt
@@ -29,6 +29,7 @@ This plugin provides:
 |latex-box-commands|                    COMMANDS
 |latex-box-commands-compilation|        Compilation
 |latex-box-commands-viewing|            Viewing
+|latex-box-commands-folding|            Folding
 |latex-box-commands-motion|             Motion
 
 |latex-box-motion|                      MOTION
@@ -37,6 +38,7 @@ This plugin provides:
 |latex-box-mappings-compilation|        Compilation
 |latex-box-mappings-insertion|          Insertion
 |latex-box-mappings-viewing|            Viewing
+|latex-box-mappings-folding|            Folding
 |latex-box-mappings-motion|             Motion
 
 |latex-box-settings|                    SETTINGS
@@ -280,6 +282,17 @@ Viewing ~
 
 ------------------------------------------------------------------------------
 
+                                                  *latex-box-commands-folding*
+Folding ~
+
+*:LatexFold*
+	Recalculate the folds in the file.
+        This is especially useful if you are editing a large file with
+        automatic folding disabled for performance reasons.
+	See |g:LatexBox_fold_automatic|.
+
+------------------------------------------------------------------------------
+
                                                    *latex-box-commands-motion*
 Motion ~
 
@@ -338,6 +351,14 @@ Viewing ~
 
 <LocalLeader>lv                                                   |:LatexView|
         View output file.
+
+------------------------------------------------------------------------------
+
+                                                  *latex-box-mappings-folding*
+Folding ~
+
+<LocalLeader>lf                                                   |:LatexFold|
+        Recalculate the folds.
 
 ------------------------------------------------------------------------------
 
@@ -621,7 +642,7 @@ turned on and a latex document is opened, the document is parsed once in order
 to define the highest fold level based on which parts and sections should be
 folded.
 
-*g:LatexBox_Folding*                    Default: undefined
+*g:LatexBox_Folding*                    Default: 0
         Set to 1 to activate LaTeX structure folding. Please note that any
         modeline that would set |foldmethod| to something else than
         'fold-expr' will disable the function. The same goes for |foldexpr|.
@@ -671,6 +692,16 @@ folded.
 
 *g:LatexBox_fold_toc_levels*            Default: 1
         Set number of section levels to fold in TOC.
+
+*g:LatexBox_fold_automatic*             Default: 1
+	Turn on/off automatic calculation of folds.
+	By default LaTeX-Box recalculates the folds every time you exit insert
+	mode. However for large files this can be a rather slow process: a
+	couple of seconds to 10s of seconds.
+	If this option is set to 0 the folding code is still enabled but isn't
+	activated by default. Hence you need to manually tell vim to
+	recalculate folds every time you find it apropriate.
+	You can recalculate the folds using <LocalLeader>lf or |:LatexFold|
 
 ==============================================================================
 

--- a/ftplugin/latex-box/folding.vim
+++ b/ftplugin/latex-box/folding.vim
@@ -12,6 +12,9 @@
 " g:LatexBox_fold_toc_levels - Set max TOC fold level
 "
 " {{{1 Initialize options to default values.
+if !exists('g:LatexBox_Folding')
+	let g:LatexBox_Folding=0
+endif
 if !exists('g:LatexBox_fold_text')
     let g:LatexBox_fold_text=1
 endif
@@ -47,30 +50,45 @@ endif
 if !exists('g:LatexBox_fold_toc_levels')
     let g:LatexBox_fold_toc_levels=1
 endif
-
+if !exists('g:LatexBox_fold_automatic')
+	let g:LatexBox_fold_automatic=1
+endif
 " }}}1
 
-if !exists('g:LatexBox_Folding') || g:LatexBox_Folding == 0
+if g:LatexBox_Folding == 0
     finish
 endif
 
 " {{{1 Set folding options for vim
-setl foldmethod=expr
 setl foldexpr=LatexBox_FoldLevel(v:lnum)
 if g:LatexBox_fold_text == 1
     setl foldtext=LatexBox_FoldText()
 endif
-"
-" The foldexpr function returns "=" for most lines, which means it can become
-" slow for large files.  The following is a hack that is based on this reply to
-" a discussion on the Vim Developer list:
-" http://permalink.gmane.org/gmane.editors.vim.devel/14100
-"
-augroup FastFold
-    autocmd!
-    autocmd InsertEnter *.tex setlocal foldmethod=manual
-    autocmd InsertLeave *.tex setlocal foldmethod=expr
-augroup end
+if g:LatexBox_fold_automatic == 1
+    setl foldmethod=expr
+
+	"
+	" The foldexpr function returns "=" for most lines, which means it can become
+	" slow for large files.  The following is a hack that is based on this reply to
+	" a discussion on the Vim Developer list:
+	" http://permalink.gmane.org/gmane.editors.vim.devel/14100
+	"
+	augroup FastFold
+		autocmd!
+		autocmd InsertEnter *.tex setlocal foldmethod=manual
+		autocmd InsertLeave *.tex setlocal foldmethod=expr
+	augroup end
+else
+	setl foldmethod=manual
+endif
+
+function! LatexBox_FoldOnDemand()
+	setl foldmethod=expr
+	normal! zx
+	setl foldmethod=manual
+endfunction
+
+command! LatexFold  call LatexBox_FoldOnDemand()
 
 " {{{1 LatexBox_FoldLevel help functions
 

--- a/ftplugin/latex-box/mappings.vim
+++ b/ftplugin/latex-box/mappings.vim
@@ -27,6 +27,12 @@ map <silent> <buffer> <LocalLeader>lt :LatexTOC<CR>
 map <silent> <buffer> <LocalLeader>lj :LatexLabels<CR>
 " }}}
 
+" Folding {{{
+if g:LatexBox_Folding == 1
+	map <buffer> <LocalLeader>lf :LatexFold<CR>
+endif
+" }}}
+
 " Jump to match {{{
 if !exists('g:LatexBox_loaded_matchparen')
 	nmap <buffer> % <Plug>LatexBox_JumpToMatch


### PR DESCRIPTION
If this is activated vim only recalculates fold upon user request.
Hence this should make editing large files a bit easier since it no
longer slows down exiting insert mode.
