### PR TITLE
corrected version check in indent/tex.vim

### DIFF
--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -114,7 +114,7 @@ endfunction
 
 " autocmd to call indent after completion
 " 7.3.598
-if v:version > 702 || (v:version == 702 && has('patch598'))
+if v:version > 703 || (v:version == 703 && has('patch598'))
 	augroup LatexBox_Completion
 		autocmd!
 		autocmd CompleteDone <buffer> call Latexbox_CallIndent()


### PR DESCRIPTION
The CompleteDone function was introduced as the comment in line 116 stated in vim 7.3.598 but the version check was against 7.2.598.
