### PR TITLE
Fix E116 (Invalid arguments) in uniq(list)

### DIFF
--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -446,7 +446,7 @@ endfunction
 " Redefine uniq() for compatibility with older Vim versions (< 7.4.218)
 function! s:uniq(list)
         if exists('*uniq')
-                return uniq(list)
+                return uniq(a:list)
         elseif len(a:list) <= 1
                 return a:list
         endif


### PR DESCRIPTION
The bug does not manifest in:
  VIM - Vi IMproved 7.3 (2010 Aug 15, compiled Sep  9 2014 16:30:51)
  Compiled by root@apple.com

but it does in:
  VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Apr 21 2014 14:54:22)
  MacOS X (unix) version
  Included patches: 1-258

It can be reproduced with this test file:

```
\documentclass[a4paper,draft]{article}
\title{Foo}
\author{Bar}
\begin{document}
\sec
Foo Bar
\end{document}
```

(The `\sec` error is intentional.)

`:Latexmk!` gives

```
Error detected while processing function
LatexBox_Latexmk..LatexBox_LatexErrors..<SNR>55_log_contains_error..<SNR>55_uniq:
line    2:
E121: Undefined variable: list
E116: Invalid arguments for function uniq(list)
E15: Invalid expression: uniq(list)
Error detected while processing function
LatexBox_Latexmk..LatexBox_LatexErrors..<SNR>55_log_contains_error:
line    3:
E706: Variable type mismatch for: lines
Compiling to pdf ... failed!
```
