### PR TITLE
Make findmain work with '*latexmain' in wildignore

### DIFF
--- a/ftplugin/latex-box/findmain.vim
+++ b/ftplugin/latex-box/findmain.vim
@@ -30,7 +30,7 @@ function! LatexBox_GetMainFileName(...)
 	" move up the directory tree until we find a .latexmain file.
 	" TODO: Should we be doing this recursion by default, or should there be a
 	"       setting?
-	while glob('*.latexmain') == ''
+	while glob('*.latexmain',1) == ''
 		let dirmodifier = dirmodifier.':h'
 		let dirNew = fnameescape(expand(dirmodifier))
 		" break from the loop if we cannot go up any further.
@@ -41,7 +41,7 @@ function! LatexBox_GetMainFileName(...)
 		exe 'cd '.dirLast
 	endwhile
 
-	let lheadfile = glob('*.latexmain')
+	let lheadfile = glob('*.latexmain',1)
 	if lheadfile != ''
 		" Remove the trailing .latexmain part of the filename... We never want
 		" that.


### PR DESCRIPTION
The problem is that if you have `*.latexmain` in your `wildignore` for convenience, then latex-box will ask you for main `.tex` file every time you start a new vim session. 

This happens because the function `LatexBox_GetMainFileName(...)` that should return the main file name relies on using `glob(..)` to detect `main.tex.latexmain`.  However by default `glob('pattern')` returns nothing if `pattern` is in `wildignore`,  unless glob is called with optional flag like `glob('pattern',1)`. Consequently now vim is unable to determine the main file and asks to reference it once again each time a new session is started.

Solution: add the flag like this `glob('*.latexmain') -> glob('*.latexmain',1)`
