### PR TITLE
Mac LatexBox_Viewer

### DIFF
--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -260,15 +260,12 @@ function! LatexBox_View(...)
 		echomsg fnamemodify(outfile, ':.') . ' is not readable'
 		return
 	endif
-	echo outfile
 	let cmd = g:LatexBox_viewer . ' ' . lvargs . ' ' . shellescape(outfile)
-	echo cmd
 	if has('win32')
 		let cmd = '!start /b ' . cmd . ' >nul'
 	else
 		let cmd = '!' . cmd . ' &>/dev/null &'
 	endif
-	echo 'true'
 	silent execute cmd
 	if !has("gui_running")
 		redraw!

--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -239,12 +239,18 @@ endfunction
 
 " Default pdf viewer
 if !exists('g:LatexBox_viewer')
-	if has('win32')
-		" On windows, 'running' a file will open it with the default program
-		let g:LatexBox_viewer = ''
-	else
-		let g:LatexBox_viewer = 'xdg-open'
+	" On windows, 'running' a file will open it with the default program
+	let s:viewer = ''
+	if has('unix')
+	  " echo -n necessary as uname -s will append \n otherwise
+      let s:uname = system('echo -n $(uname -s)')
+	  if s:uname == "Darwin"
+		  let s:viewer = 'open'
+	  else
+		  let s:viewer = 'xdg-open'
+	  endif
 	endif
+	let g:LatexBox_viewer = s:viewer
 endif
 
 function! LatexBox_View(...)
@@ -254,12 +260,15 @@ function! LatexBox_View(...)
 		echomsg fnamemodify(outfile, ':.') . ' is not readable'
 		return
 	endif
+	echo outfile
 	let cmd = g:LatexBox_viewer . ' ' . lvargs . ' ' . shellescape(outfile)
+	echo cmd
 	if has('win32')
 		let cmd = '!start /b ' . cmd . ' >nul'
 	else
 		let cmd = '!' . cmd . ' &>/dev/null &'
 	endif
+	echo 'true'
 	silent execute cmd
 	if !has("gui_running")
 		redraw!


### PR DESCRIPTION
Currently, LatexBox will only opens pdfs with `xdg-open`, which is the correct program to use on several Linux distributions including Ubuntu.

However, Mac OS X will use the program `open` to do something similar. 

The following patch provides Mac users with builtin LatexBox_View support, improving the functionality of the plugin while decreasing a user's required knowledge of the codebase (no need to set an environment variable in `.vimrc` now).