### PR TITLE
fix the \right and \left regex in indent/tex.vim

### DIFF
--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -17,8 +17,8 @@ let s:list_envs = ['itemize', 'enumerate', 'description']
 " indent on \left( and on \(, but not on (
 " indent on \left[ and on \[, but not on [
 " indent on \left\{ and on {, but not on \{
-let s:open_pat = '\\\@<!\%(\\begin\|\\left\|\\(\|\\\[\|{\)'
-let s:close_pat = '\\\@<!\%(\\end\|\\right\|\\)\|\\\]\|}\)'
+let s:open_pat = '\\\@<!\%(\\begin\|\\left\a\@!\|\\(\|\\\[\|{\)'
+let s:close_pat = '\\\@<!\%(\\end\|\\right\a\@!\|\\)\|\\\]\|}\)'
 let s:list_open_pat = '\\\@<!\\begin{\%(' . join(s:list_envs, '\|') . '\)}'
 let s:list_close_pat	= '\\\@<!\\end{\%(' . join(s:list_envs, '\|') . '\)}'
 


### PR DESCRIPTION
The indentation file usually works, but there's a small issue with the regex for opening and closing patterns. The issue is that "\left" and "\right" get matched even when they're part of a longer command, like "\rightarrow", or "\leftrightarrow". This wreaks havoc with indentation when you use these commands. The fix I propose should only match "\left" and "\right" when they're not followed by an alphabetical character. 