### PR TITLE
Memoir support

### DIFF
--- a/ftplugin/latex-box/motion.vim
+++ b/ftplugin/latex-box/motion.vim
@@ -349,7 +349,7 @@ function! s:ReadTOC(auxfile, texfile, ...)
 		if len(tree) > 3 && empty(tree[1])
 			call remove(tree, 1)
 		endif
-		if len(tree) > 1 && type(tree[0]) == type("") && tree[0] =~ '^\\\(numberline\|tocsection\)'
+		if len(tree) > 1 && type(tree[0]) == type("") && tree[0] =~ '^\\\(\(chapter\)\?numberline\|tocsection\)'
 			let secnum = LatexBox_TreeToTex(tree[1])
 			let secnum = substitute(secnum, '\\\S\+\s', '', 'g')
 			let secnum = substitute(secnum, '\\\S\+{\(.\{-}\)}', '\1', 'g')
@@ -359,7 +359,7 @@ function! s:ReadTOC(auxfile, texfile, ...)
 		" parse section title
 		let text = LatexBox_TreeToTex(tree)
 		let text = substitute(text, '^{\+\|}\+$',                 '', 'g')
-		let text = substitute(text, '\m^\\\(no\)\?numberline\s*', '', '')
+		let text = substitute(text, '\m^\\\(no\)\?\(chapter\)\?numberline\s*', '', '')
 		let text = substitute(text, '\*',                         '', 'g')
 
 		" add TOC entry


### PR DESCRIPTION
The memoir class uses chapternumberline instead of numberline for chapters. This addition enables it to end up correctly in the TOC.