### PR TITLE
add support for shell=fish

### DIFF
--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -264,7 +264,12 @@ function! LatexBox_View(...)
 	if has('win32')
 		let cmd = '!start /b ' . cmd . ' >nul'
 	else
-		let cmd = '!' . cmd . ' &>/dev/null &'
+		let cmd = '!' . cmd . ' '
+		if fnamemodify(&shell, ':t') ==# 'fish'
+			let cmd .= ' >/dev/null ^/dev/null &'
+		else
+			let cmd .= ' &>/dev/null &'
+		endif
 	endif
 	silent execute cmd
 	if !has("gui_running")

--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -166,7 +166,11 @@ function! LatexBox_Latexmk(force)
 	elseif match(&shell, '/tcsh$') >= 0
 		let env = 'setenv max_print_line ' . max_print_line . '; '
 	else
-		let env = 'max_print_line=' . max_print_line
+		if fnamemodify(&shell, ':t') ==# 'fish'
+			let env = 'set max_print_line ' . max_print_line . '; and '
+		else
+			let env = 'max_print_line=' . max_print_line
+		endif
 	endif
 
 	" Set environment options
@@ -177,7 +181,11 @@ function! LatexBox_Latexmk(force)
 		" Make sure to switch drive as well as directory
 		let cmd = 'cd /D ' . texroot . ' && '
 	else
-		let cmd = 'cd ' . texroot . ' && '
+		if fnamemodify(&shell, ':t') ==# 'fish'
+			let cmd = 'cd ' . texroot . '; and '
+		else
+			let cmd = 'cd ' . texroot . ' && '
+		endif
 	endif
 	let cmd .= env . ' latexmk'
 	if ! g:LatexBox_personal_latexmkrc
@@ -203,7 +211,11 @@ function! LatexBox_Latexmk(force)
 	if has('win32')
 		let cmd .= ' >nul'
 	else
-		let cmd .= ' &>/dev/null'
+		if fnamemodify(&shell, ':t') ==# 'fish'
+			let cmd .= ' >/dev/null ^/dev/null'
+		else
+			let cmd .= ' &>/dev/null'
+		endif
 	endif
 
 	if g:LatexBox_latexmk_async


### PR DESCRIPTION
Currently, LaTeX-Box silently fails when the user has their shell set to fish. This patch makes things work as expected.