### PR TITLE
Fix for #240, smartly changes cursor position when typing auto-indented keyword

### DIFF
--- a/indent/tex.vim
+++ b/indent/tex.vim
@@ -101,8 +101,20 @@ function! Latexbox_CallIndent()
   let window = getpos('.')
   call setpos('.', cursor)
 
+  " Get first non-whitespace character of current line.
+  let line_start_char = matchstr(getline('.'), '\S')
+
+  " Get initial tab position.
+  let initial_tab = stridx(getline('.'), line_start_char)
+
   " Execute the command.
   execute 'normal! =='
+
+  " Get tab position difference.
+  let difference = stridx(getline('.'), line_start_char) - initial_tab
+
+  " Set new cursor Y position based on calculated difference.
+  let cursor[2] = cursor[2] + difference
 
   " Restore the previous window position.
   call setpos('.', window)


### PR DESCRIPTION
Fixes #240 

Just to show what the bug was, this is how it was before:

![apr 20 2015 09 37](https://cloud.githubusercontent.com/assets/2029031/7231205/0608d570-e742-11e4-8bce-ce77b7c1e914.gif)

This is the fix:

![apr 20 2015 09 36](https://cloud.githubusercontent.com/assets/2029031/7231217/1a5ee866-e742-11e4-8c01-043fa67fce3f.gif)

It just adds the tab difference to the Y position of the cursor when setting it.