### PR TITLE
Handle custom jobname

### DIFF
--- a/doc/latex-box.txt
+++ b/doc/latex-box.txt
@@ -609,6 +609,9 @@ Compilation ~
         Set output directory for build files. This overrides the global
         setting.
 
+*g:LatexBox_jobname*                            Default: ""
+        Sets the name of the output build files.
+
 ------------------------------------------------------------------------------
 
                                                   *latex-box-settings-windows*

--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -179,7 +179,13 @@ function! LatexBox_GetTexRoot()
 	return fnamemodify(LatexBox_GetMainTexFile(), ':h')
 endfunction
 
-function! LatexBox_GetTexBasename(with_dir)
+function! LatexBox_GetBuildBasename(with_dir)
+	" 1. Check for g:LatexBox_jobname
+	if exists('g:LatexBox_jobname')
+		return g:LatexBox_jobname
+	endif
+
+	" 2. Get the basename from the main tex file
 	if a:with_dir
 		return fnamemodify(LatexBox_GetMainTexFile(), ':r')
 	else
@@ -190,48 +196,48 @@ endfunction
 function! LatexBox_GetAuxFile()
 	" 1. check for b:build_dir variable
 	if exists('b:build_dir') && isdirectory(b:build_dir)
-		return b:build_dir . '/' . LatexBox_GetTexBasename(0) . '.aux'
+		return b:build_dir . '/' . LatexBox_GetBuildBasename(0) . '.aux'
 	endif
 
 	" 2. check for g:LatexBox_build_dir variable
 	if exists('g:LatexBox_build_dir') && isdirectory(g:LatexBox_build_dir)
-		return g:LatexBox_build_dir . '/' . LatexBox_GetTexBasename(0) . '.aux'
+		return g:LatexBox_build_dir . '/' . LatexBox_GetBuildBasename(0) . '.aux'
 	endif
 
 	" 3. use the base name of main tex file
-	return LatexBox_GetTexBasename(1) . '.aux'
+	return LatexBox_GetBuildBasename(1) . '.aux'
 endfunction
 
 function! LatexBox_GetLogFile()
 	" 1. check for b:build_dir variable
 	if exists('b:build_dir') && isdirectory(b:build_dir)
-		return b:build_dir . '/' . LatexBox_GetTexBasename(0) . '.log'
+		return b:build_dir . '/' . LatexBox_GetBuildBasename(0) . '.log'
 	endif
 
 	" 2. check for g:LatexBox_build_dir variable
 	if exists('g:LatexBox_build_dir') && isdirectory(g:LatexBox_build_dir)
-		return g:LatexBox_build_dir . '/' . LatexBox_GetTexBasename(0) . '.log'
+		return g:LatexBox_build_dir . '/' . LatexBox_GetBuildBasename(0) . '.log'
 	endif
 
 	" 3. use the base name of main tex file
-	return LatexBox_GetTexBasename(1) . '.log'
+	return LatexBox_GetBuildBasename(1) . '.log'
 endfunction
 
 function! LatexBox_GetOutputFile()
 	" 1. check for b:build_dir variable
 	if exists('b:build_dir') && isdirectory(b:build_dir)
-		return b:build_dir . '/' . LatexBox_GetTexBasename(0)
+		return b:build_dir . '/' . LatexBox_GetBuildBasename(0)
 					\ . '.' . g:LatexBox_output_type
 	endif
 
 	" 2. check for g:LatexBox_build_dir variable
 	if exists('g:LatexBox_build_dir') && isdirectory(g:LatexBox_build_dir)
-		return g:LatexBox_build_dir . '/' . LatexBox_GetTexBasename(0)
+		return g:LatexBox_build_dir . '/' . LatexBox_GetBuildBasename(0)
 					\ . '.' . g:LatexBox_output_type
 	endif
 
 	" 3. use the base name of main tex file
-	return LatexBox_GetTexBasename(1) . '.' . g:LatexBox_output_type
+	return LatexBox_GetBuildBasename(1) . '.' . g:LatexBox_output_type
 endfunction
 " }}}
 

--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -141,7 +141,7 @@ endfunction
 
 function! LatexBox_Latexmk(force)
 	" Define often used names
-	let basepath = LatexBox_GetTexBasename(1)
+	let basepath = LatexBox_GetBuildBasename(1)
 	let basename = fnamemodify(basepath, ':t')
 	let texroot = shellescape(LatexBox_GetTexRoot())
 	let mainfile = fnameescape(fnamemodify(LatexBox_GetMainTexFile(), ':t'))
@@ -369,7 +369,7 @@ function! LatexBox_LatexmkClean(cleanall)
 		return
 	endif
 
-	let basename = LatexBox_GetTexBasename(1)
+	let basename = LatexBox_GetBuildBasename(1)
 
 	if has_key(g:latexmk_running_pids, basename)
 		echomsg "don't clean when latexmk is running"
@@ -502,7 +502,7 @@ function! LatexBox_LatexmkStatus(detailed)
 			echo "latexmk is running (" . plist . ")"
 		endif
 	else
-		let basename = LatexBox_GetTexBasename(1)
+		let basename = LatexBox_GetBuildBasename(1)
 		if has_key(g:latexmk_running_pids, basename)
 			echo "latexmk is running"
 		else
@@ -516,12 +516,12 @@ endfunction
 function! LatexBox_LatexmkStop(silent)
 	if empty(g:latexmk_running_pids)
 		if !a:silent
-			let basepath = LatexBox_GetTexBasename(1)
+			let basepath = LatexBox_GetBuildBasename(1)
 			let basename = fnamemodify(basepath, ':t')
 			echoerr "latexmk is not running for `" . basename . "'"
 		endif
 	else
-		let basepath = LatexBox_GetTexBasename(1)
+		let basepath = LatexBox_GetBuildBasename(1)
 		let basename = fnamemodify(basepath, ':t')
 		if has_key(g:latexmk_running_pids, basepath)
 			call s:kill_latexmk_process(g:latexmk_running_pids[basepath])


### PR DESCRIPTION
Assuming my master file is named `master.tex`, and my latexmk config includes a custom jobname `thesis`, Latex-Box generated the following error:

```
Compiling to pdf ... (async off!)
Error detected while processing function LatexBox_Latexmk..LatexBox_LatexErrors:
line   16:
E40: Can't open errorfile build/master.log
Error detected while processing function LatexBox_Latexmk:
line  210:
E171: Missing :endif
Press ENTER or type command to continue
```

This commit adds a `g:LatexBox_jobname` option for custom jobname.