### PR TITLE
'&>...' redirects break non-bash; change to '>... 2>&1' redirects

### DIFF
--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -274,7 +274,7 @@ function! LatexBox_View(...)
 		if fnamemodify(&shell, ':t') ==# 'fish'
 			let cmd .= ' >/dev/null ^/dev/null &'
 		else
-			let cmd .= ' &>/dev/null &'
+			let cmd .= ' >/dev/null 2>&1 &'
 		endif
 	endif
 	silent execute cmd

--- a/ftplugin/latex-box/latexmk.vim
+++ b/ftplugin/latex-box/latexmk.vim
@@ -214,7 +214,7 @@ function! LatexBox_Latexmk(force)
 		if fnamemodify(&shell, ':t') ==# 'fish'
 			let cmd .= ' >/dev/null ^/dev/null'
 		else
-			let cmd .= ' &>/dev/null'
+			let cmd .= ' >/dev/null 2>&1'
 		endif
 	endif
 
@@ -390,7 +390,7 @@ function! LatexBox_LatexmkClean(cleanall)
 	if has('win32')
 		let cmd .= ' >nul'
 	else
-		let cmd .= ' >&/dev/null'
+		let cmd .= ' >/dev/null 2>&1'
 	endif
 
 	call system(cmd)


### PR DESCRIPTION
This change is semantically equivalent according to the [bash documentation](https://www.gnu.org/software/bash/manual/bashref.html#Redirecting-Standard-Output-and-Standard-Error) and it makes latex-box work on ksh (the public domain korn shell).
