### PR TITLE
Adding \nobibliography to bibliography commands

### DIFF
--- a/ftplugin/latex-box/complete.vim
+++ b/ftplugin/latex-box/complete.vim
@@ -206,6 +206,7 @@ function! s:FindBibData(...)
 	"
 	let bibliography_cmds = [
 				\ '\\bibliography',
+				\ '\\nobibliography',
 				\ '\\addbibresource',
 				\ '\\addglobalbib',
 				\ '\\addsectionbib',


### PR DESCRIPTION
The bibentry package is especially useful in Beamer presentations, and requires a bibliography be loaded using the "\nobibliography" command.

This pull request just adds this command to the list of potential bibliography commands
