### PR TITLE
Fix bug with TOC creation and searching when documentclass is amsart. 

### DIFF
--- a/ftplugin/latex-box/motion.vim
+++ b/ftplugin/latex-box/motion.vim
@@ -349,26 +349,31 @@ function! s:ReadTOC(auxfile, texfile, ...)
 		if len(tree) > 3 && empty(tree[1])
 			call remove(tree, 1)
 		endif
-		if len(tree) > 1 && type(tree[0]) == type("") && tree[0] =~ '^\\\(\(chapter\)\?numberline\|tocsection\)'
-			let secnum = LatexBox_TreeToTex(tree[1])
-			let secnum = substitute(secnum, '\\\S\+\s', '', 'g')
-			let secnum = substitute(secnum, '\\\S\+{\(.\{-}\)}', '\1', 'g')
-			let secnum = substitute(secnum, '^{\+\|}\+$', '', 'g')
-			call remove(tree, 1)
-		endif
-		" parse section title
-		let text = LatexBox_TreeToTex(tree)
-		let text = substitute(text, '^{\+\|}\+$',                 '', 'g')
-		let text = substitute(text, '\m^\\\(no\)\?\(chapter\)\?numberline\s*', '', '')
-		let text = substitute(text, '\*',                         '', 'g')
 
-		" add TOC entry
-		call add(fileindices[texfile], len(toc))
-		call add(toc, {'file': texfile,
-					\ 'level': level,
-					\ 'number': secnum,
-					\ 'text': text,
-					\ 'page': page})
+		" only include section types we know how to parse.
+		if len(tree) > 1 && type(tree[0]) == type("") && tree[0] =~ '^\\\(chapter\)\?\(numberline\|toc\(sub\)*section\)'
+			
+			if len(tree[1]) >= 1
+				" Check if tree[1] has at least one string under it.
+				let secnum = tree[1][0] 
+			endif
+			
+
+			" parse section title
+			let text = LatexBox_TreeToTex(tree[2])
+			let text = substitute(text, '^{\+\|}\+$','', 'g')
+			let text = substitute(text, '\m^\\\(no\)\?\(chapter\)\?\(numberline\|toc\(sub\)*section\s*{\)\s*', '', '')
+			
+			" add TOC entry
+			call add(fileindices[texfile], len(toc))
+			call add(toc, {'file': texfile,
+						\ 'level': level,
+						\ 'number': secnum,
+						\ 'text': text,
+						\ 'page': page})
+			
+		endif
+
 	endfor
 
 	return [toc, fileindices]

--- a/ftplugin/latextoc.vim
+++ b/ftplugin/latextoc.vim
@@ -43,6 +43,8 @@ function! s:EscapeTitle(titlestr)
     let titlestr = substitute(a:titlestr, '\\[a-zA-Z@]*\>\s*{\?', '.*', 'g')
     let titlestr = substitute(titlestr, '}', '', 'g')
     let titlestr = substitute(titlestr, '\%(\.\*\s*\)\{2,}', '.*', 'g')
+    " replaces equations in titles with .* 
+    let titlestr = substitute(titlestr, '\$.*\$', '.*','g')
     return titlestr
 endfunction
 


### PR DESCRIPTION
This was because sections that appeared as `\toc\(sub\)*section` in the aux file were not being parsed correctly by ReadTOC in motion.vim

I also changed it so that it would only add entries to the TOC that we
knew how to parse. This changes its previous behavior, where things
sections that appeared as `\tocpart` in the aux file would be added to the TOC.

Removed some substitutions for secnum and text. The title text is not as
pleasing, but it's complete.

Fix search bug in latextoc.vim when `$ $` equations were present in the
title str. I changed this in s:EscapeTitle in latextoc.vim. For example

```
    \section{Test $asd_{12}$ $\mathcal{b}$}
```

This method of escaping will certainly produce duplicate matches in some
scenarios.
