### PR TITLE
Fix detection of latex warnings and filenames therein

### DIFF
--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -45,11 +45,13 @@ if g:LatexBox_show_warnings
 	endfor
 	setlocal efm+=%+WLaTeX\ %.%#Warning:\ %.%#line\ %l%.%#
 	setlocal efm+=%+W%.%#\ at\ lines\ %l--%*\\d
+	setlocal efm+=%+W%.%#\ at\ line\ %l
 	setlocal efm+=%+WLaTeX\ %.%#Warning:\ %m
 	setlocal efm+=%+W%.%#Warning:\ %m
 else
 	setlocal efm+=%-WLaTeX\ %.%#Warning:\ %.%#line\ %l%.%#
 	setlocal efm+=%-W%.%#\ at\ lines\ %l--%*\\d
+	setlocal efm+=%-W%.%#\ at\ line\ %l
 	setlocal efm+=%-WLaTeX\ %.%#Warning:\ %m
 	setlocal efm+=%-W%.%#Warning:\ %m
 endif

--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -61,14 +61,21 @@ endif
 setlocal efm+=%+P**%f
 setlocal efm+=%+P**\"%f\"
 
-" The following lines are based on the |errorformat-LaTeX| example.
-setlocal efm+=%-O(%f)
-setlocal efm+=%-P\ %\\=(%f
-setlocal efm+=%-P%*[^()](%f
-setlocal efm+=%-P[%\\d%[^()]%#(%f
-setlocal efm+=%-Q)
-setlocal efm+=%-Q%*[^()])
-setlocal efm+=%-Q[%\\d%*[^()])
+" Ignore package info messages
+" Also prevent parenthesized package names in those messages to be parsed as
+" path.
+setlocal efm+=%-IPackage\ %m\ on\ input\ line\ %l.%\\=
+setlocal efm+=%-IPackage\ %m
+setlocal efm+=%C(%.%#)\ \ \ \ \ \ \ \ %.%#
+
+" Further file stack parsing
+" ( opens a file, ) closes a file, page number are given in brackets and are
+" omitted.
+setlocal efm+=%-P\ %\\=(%f%r
+setlocal efm+=%-Q)%r
+setlocal efm+=%-O[%*\\d]%r
+setlocal efm+=%-O[%.%#
+setlocal efm+=%-O]%r
 
 " Ignore unmatched lines
 setlocal efm+=%-G%.%#

--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -48,6 +48,7 @@ if g:LatexBox_show_warnings
 	setlocal efm+=%+W%.%#\ at\ line\ %l
 	setlocal efm+=%+WLaTeX\ %.%#Warning:\ %m
 	setlocal efm+=%+W%.%#Warning:\ %m
+	setlocal efm+=%+W%moutput\ is\ active\ %.%#
 else
 	setlocal efm+=%-WLaTeX\ %.%#Warning:\ %.%#line\ %l%.%#
 	setlocal efm+=%-W%.%#\ at\ lines\ %l--%*\\d

--- a/ftplugin/latex-box/common.vim
+++ b/ftplugin/latex-box/common.vim
@@ -58,6 +58,15 @@ endif
 setlocal efm+=%+P**%f
 setlocal efm+=%+P**\"%f\"
 
+" The following lines are based on the |errorformat-LaTeX| example.
+setlocal efm+=%-O(%f)
+setlocal efm+=%-P\ %\\=(%f
+setlocal efm+=%-P%*[^()](%f
+setlocal efm+=%-P[%\\d%[^()]%#(%f
+setlocal efm+=%-Q)
+setlocal efm+=%-Q%*[^()])
+setlocal efm+=%-Q[%\\d%*[^()])
+
 " Ignore unmatched lines
 setlocal efm+=%-G%.%#
 " }}}


### PR DESCRIPTION
I am using LaTeX-Box with lualatex and a document that includes subdocuments with `\include` and noticed that in warnings the filenames where not correctly detected (every warning was attributed to the main file). Also, warnings related to a single line (`at line X` instead of `at lines X-Y`) and underfull box warnings (which have no line number at all) were not detected. (Note that the “underfull” warnings are ignored by default, but I configured `g:LatexBox_ignore_warnings` to not ignore those).